### PR TITLE
fix vnstock 3mo interval mapping

### DIFF
--- a/agents/data_agent.py
+++ b/agents/data_agent.py
@@ -128,7 +128,7 @@ class DataAgent(BaseAgent):
                 "5d": "1D",
                 "1wk": "1W",
                 "1mo": "1M",
-                "3mo": "1M",
+                "3mo": "3M",
             }
             vn_interval = interval_map.get(interval, "1D")  # type: ignore[arg-type]
             start_str = start.strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- fix quarterly interval mapping for vnstock data source

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad88c7d7b08325844a05614f3309ed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the 3-month interval mapping for Vietnam stock data to use a true 3M cadence, improving data accuracy and consistency when requesting 3-month intervals.
  * No changes to public APIs; existing workflows and fallbacks continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->