### PR TITLE
Refactor team managers and add trading graph

### DIFF
--- a/agents/analysts/fundamental_analyst.py
+++ b/agents/analysts/fundamental_analyst.py
@@ -1,5 +1,3 @@
-from agno.tools.googlesearch import GoogleSearchTools
-
 from utils.model_factory import build_default_model
 
 from ..base_agent import BaseAgent
@@ -12,11 +10,12 @@ class FundamentalAnalyst(BaseAgent):
     def __init__(self) -> None:  # noqa: D401
         super().__init__(
             model=build_default_model(),
-            tools=[GoogleSearchTools(), vn_company_overview, vn_finance_report],
+            tools=[vn_company_overview, vn_finance_report],
             instructions=(
-                "You are a meticulous Fundamental Analyst for a trading firm. "
-                "Analyze company's financial health (P/E, D/E, growth, margins, cash flows). "
-                "Use tools when needed. Return a concise data-driven summary and a Bullish/Bearish/Neutral view."
+                "You are a fundamentals researcher focused on Vietnamese equities. "
+                "Use the provided tools to retrieve company profiles and financial statements. "
+                "Write a concise markdown report covering profitability, growth, leverage and cash flow. "
+                "Conclude with an overall view: Bullish, Bearish or Neutral, and include a small markdown table of key ratios."
             ),
             name="fundamental-analyst",
             agent_id="fundamental-analyst",

--- a/agents/analysts/news_analyst.py
+++ b/agents/analysts/news_analyst.py
@@ -3,7 +3,7 @@ from agno.tools.googlesearch import GoogleSearchTools
 from utils.model_factory import build_default_model
 
 from ..base_agent import BaseAgent
-from ..tools import vn_company_overview
+from ..tools import vn_company_news
 
 
 class NewsAnalyst(BaseAgent):
@@ -12,10 +12,12 @@ class NewsAnalyst(BaseAgent):
     def __init__(self) -> None:  # noqa: D401
         super().__init__(
             model=build_default_model(),
-            tools=[GoogleSearchTools(), vn_company_overview],
+            tools=[vn_company_news, GoogleSearchTools(fixed_language="vi")],
             instructions=(
-                "You are a sharp News Analyst. Search for and summarize recent headlines for a stock "
-                "and assess their likely impact and sentiment (Bullish/Bearish/Neutral)."
+                "You are a news researcher covering Vietnamese equities. "
+                "Review recent company news and broader macro headlines. "
+                "Summarize key catalysts and note whether each is bullish or bearish for the ticker. "
+                "Finish with a short markdown table of headline and sentiment."
             ),
             name="news-analyst",
             agent_id="news-analyst",

--- a/agents/analysts/sentiment_analyst.py
+++ b/agents/analysts/sentiment_analyst.py
@@ -3,7 +3,6 @@ from agno.tools.googlesearch import GoogleSearchTools
 from utils.model_factory import build_default_model
 
 from ..base_agent import BaseAgent
-from ..tools import vn_company_overview
 
 
 class SentimentAnalyst(BaseAgent):
@@ -12,10 +11,11 @@ class SentimentAnalyst(BaseAgent):
     def __init__(self) -> None:  # noqa: D401
         super().__init__(
             model=build_default_model(),
-            tools=[GoogleSearchTools(fixed_language="vi"), vn_company_overview],
+            tools=[GoogleSearchTools(fixed_language="vi")],
             instructions=(
-                "You are a Social Media Sentiment Analyst. Gauge market mood by searching social sources "
-                "and summarize sentiment (Bullish/Bearish/Neutral)."
+                "You are a sentiment analyst monitoring Vietnamese social media and forums (Facebook, Reddit, Voz, etc.). "
+                "Search these sources to gauge public mood on the ticker, highlight prevailing themes and classify sentiment as Bullish, Bearish or Neutral. "
+                "End with a small markdown table of source and tone."
             ),
             name="sentiment-analyst",
             agent_id="sentiment-analyst",

--- a/agents/graph/__init__.py
+++ b/agents/graph/__init__.py
@@ -1,0 +1,3 @@
+from .trading_graph import TradeState, TradingGraph
+
+__all__ = ["TradeState", "TradingGraph"]

--- a/agents/graph/trading_graph.py
+++ b/agents/graph/trading_graph.py
@@ -1,0 +1,60 @@
+"""Simple trading graph using research and risk managers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pandas as pd
+
+from ..decision_team import PortfolioManagerAgent, TraderAgent
+from ..managers import ResearchManager, RiskManager
+
+
+def _text(resp: object) -> str:
+    content = getattr(resp, "content", None)
+    return content if isinstance(content, str) else str(content or "")
+
+
+@dataclass
+class TradeState:
+    """State container flowing through the trading graph."""
+
+    symbol: str
+    bull_case: str = ""
+    bear_case: str = ""
+    trade_plan: str = ""
+    risk_debate: str = ""
+    final_decision: str = ""
+
+
+class TradingGraph:
+    """Orchestrates research, decision, and risk review."""
+
+    def __init__(self) -> None:  # noqa: D401
+        self.research = ResearchManager()
+        self.risk = RiskManager()
+        self.trader = TraderAgent()
+        self.pm = PortfolioManagerAgent()
+
+    async def run(self, symbol: str, ohlcv: pd.DataFrame) -> TradeState:
+        """Execute the trading workflow and return accumulated state."""
+        state = TradeState(symbol=symbol)
+
+        # Research and debate
+        state.bull_case, state.bear_case = await self.research.run(symbol, ohlcv)
+        debate = f"## Bullish Case\n{state.bull_case}\n\n## Bearish Case\n{state.bear_case}"
+
+        # Trader plan
+        trade_resp = await asyncio.to_thread(self.trader.decide, debate)
+        state.trade_plan = _text(trade_resp)
+
+        # Risk debate
+        state.risk_debate = await self.risk.run(state.trade_plan)
+
+        # Portfolio manager decision
+        pm_input = f"{state.trade_plan}\n\n### Risk Debate\n{state.risk_debate}"
+        pm_resp = await asyncio.to_thread(self.pm.approve, pm_input)
+        state.final_decision = _text(pm_resp)
+
+        return state

--- a/agents/managers/__init__.py
+++ b/agents/managers/__init__.py
@@ -1,0 +1,4 @@
+from .research_manager import ResearchManager
+from .risk_manager import RiskManager
+
+__all__ = ["ResearchManager", "RiskManager"]

--- a/agents/managers/research_manager.py
+++ b/agents/managers/research_manager.py
@@ -1,0 +1,112 @@
+"""High-level research manager orchestrating analyst synthesis and debate."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pandas as pd
+from agno.team import Team
+
+from utils import technical_analysis as ta_utils
+from utils.logging import log_info
+from ..researchers.research_team import (
+    BearishResearcher,
+    BullishResearcher,
+    FundamentalsAgent,
+    NewsAgent,
+    SentimentAgent,
+    SocialMediaAgent,
+    TechnicalResearchAgent,
+)
+
+
+def _text(resp: object) -> str:
+    content = getattr(resp, "content", None)
+    return content if isinstance(content, str) else str(content or "")
+
+
+ANALYSTS = [
+    FundamentalsAgent(),
+    SentimentAgent(),
+    NewsAgent(),
+    TechnicalResearchAgent(),
+    SocialMediaAgent(),
+]
+
+DEBATERS = [BullishResearcher(), BearishResearcher()]
+
+
+TEAM_PROMPT = (
+    "You are a financial research team analyzing {symbol}.\n"
+    "Coordinate among members to produce a concise synthesis with this exact structure (markdown):\n\n"
+    "### Synthesis\n"
+    "- Fundamentals: <2 short bullets>\n"
+    "- Sentiment: <2 short bullets>\n"
+    "- News/Catalysts: <2 short bullets>\n"
+    "- Technicals: <2 short bullets>\n"
+    "- Social Media: <2 short bullets>\n\n"
+    "### Key Risks\n"
+    "- bullet\n- bullet\n\n"
+    "### Watchlist\n"
+    "- bullet\n- bullet\n\n"
+    "Do not include any internal steps or tool metadata.\n\n"
+    "Technical Snapshot (latest):\n{tech}"
+)
+
+DEBATE_PROMPT = (
+    "You are the Research Debate Team (Bullish Researcher, Bearish Researcher).\n"
+    "Work in order: Bullish -> Bearish. Produce ONE consolidated markdown output with these sections:\n\n"
+    "## Bullish Case\n"
+    "- bullet 1\n- bullet 2\n- bullet 3\n\n"
+    "## Bearish Case\n"
+    "- bullet 1\n- bullet 2\n- bullet 3\n\n"
+    "Do not include internal steps or tool calls.\n\n"
+    "Context:\n{report}"
+)
+
+
+def _split_cases(text: str) -> tuple[str, str]:
+    bull_marker, bear_marker = "## Bullish Case", "## Bearish Case"
+    if bull_marker in text and bear_marker in text:
+        bull = text.split(bull_marker, 1)[1].split(bear_marker)[0].strip()
+        bear = text.split(bear_marker, 1)[1].strip()
+        return bull, bear
+    return text, ""
+
+
+class ResearchManager:
+    """Coordinates analyst synthesis and bull/bear debate using Agno Teams."""
+
+    def __init__(self) -> None:
+        self.analyst_team = Team(
+            name="Research Team",
+            mode="coordinate",
+            members=ANALYSTS,
+            show_members_responses=False,
+            markdown=True,
+            telemetry=False,
+        )
+        self.debate_team = Team(
+            name="Research Debate Team",
+            mode="coordinate",
+            members=DEBATERS,
+            show_members_responses=True,
+            markdown=True,
+            telemetry=False,
+        )
+
+    async def run(self, symbol: str, ohlcv: pd.DataFrame) -> tuple[str, str]:
+        """Run synthesis then debate, returning bull and bear cases."""
+        log_info("[ResearchManager] Computing technical snapshot for context...")
+        enriched = await asyncio.to_thread(ta_utils.compute_indicators, ohlcv)
+        latest = enriched.tail(1).T.reset_index()
+        latest.columns = ["Indicator", "Value"]
+        tech_table = latest.to_markdown(index=False)  # type: ignore[arg-type]
+
+        prompt = TEAM_PROMPT.format(symbol=symbol, tech=tech_table)
+        synth = _text(await asyncio.to_thread(self.analyst_team.run, prompt))
+        report = f"--- Team Synthesis ---\n{synth}\n\n--- Technicals (latest) ---\n{tech_table}"
+
+        debate = DEBATE_PROMPT.format(report=report)
+        result = _text(await asyncio.to_thread(self.debate_team.run, debate))
+        return _split_cases(result)

--- a/agents/managers/risk_manager.py
+++ b/agents/managers/risk_manager.py
@@ -1,0 +1,80 @@
+"""Risk manager coordinating conservative, neutral, and aggressive debates."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agno.team import Team
+from agno.tools.reasoning import ReasoningTools  # type: ignore
+
+from utils.model_factory import build_default_model
+from ..base_agent import BaseAgent
+
+
+def _text(resp: object) -> str:
+    content = getattr(resp, "content", None)
+    return content if isinstance(content, str) else str(content or "")
+
+
+def _make_debater(role: str, instructions: str) -> BaseAgent:
+    return BaseAgent(
+        model=build_default_model(),
+        tools=[ReasoningTools(add_instructions=True)],
+        instructions=instructions,
+        name=f"{role.lower()}-debater",
+        agent_id=f"{role.lower()}-debater",
+        description=f"{role} risk debater",
+        monitoring=False,
+    )
+
+
+RISK_VIEWS = {
+    "Conservative": (
+        "You are a conservative risk analyst for Vietnamese equities. "
+        "Highlight worst-case scenarios, regulatory or liquidity risks, and position-sizing limits. Provide 2 concise bullets."
+    ),
+    "Neutral": (
+        "You are a neutral risk analyst bridging bullish and bearish views for Vietnamese equities. "
+        "Weigh upside versus downside and note catalysts that could shift the balance. Provide 2 concise bullets."
+    ),
+    "Aggressive": (
+        "You are an aggressive risk analyst for Vietnamese markets. "
+        "Argue why potential rewards outweigh the dangers and where risks can be hedged. Provide 2 concise bullets."
+    ),
+}
+
+
+RISK_PROMPT = (
+    "You are the Risk Debate Team (Conservative, Neutral, Aggressive).\n"
+    "Work in order: Conservative -> Neutral -> Aggressive. Produce ONE consolidated markdown output with these sections:\n\n"
+    "### Risk Debate\n"
+    "#### Conservative View\n- bullet 1\n- bullet 2\n\n"
+    "#### Neutral View\n- bullet 1\n- bullet 2\n\n"
+    "#### Aggressive View\n- bullet 1\n- bullet 2\n\n"
+    "#### Summary\n- One sentence jointly summarizing the risk stance.\n\n"
+    "Do not include internal steps or tool calls.\n\n"
+    "Context:\n{trade}"
+)
+
+
+class RiskManager:
+    """Coordinates a risk debate team to assess the trade plan."""
+
+    def __init__(self) -> None:
+        self.debaters = [
+            _make_debater(role, instr) for role, instr in RISK_VIEWS.items()
+        ]
+        self.team = Team(
+            name="Risk Debate Team",
+            members=self.debaters,
+            mode="coordinate",
+            show_members_responses=True,
+            markdown=True,
+            telemetry=False,
+        )
+
+    async def run(self, trade_plan: str, **kwargs) -> str:
+        """Run the risk debate and return structured markdown."""
+        prompt = RISK_PROMPT.format(trade=trade_plan)
+        resp = await asyncio.to_thread(self.team.run, prompt, **kwargs)
+        return _text(resp)

--- a/agents/researchers/research_team.py
+++ b/agents/researchers/research_team.py
@@ -13,6 +13,7 @@ from typing import Sequence
 
 import pandas as pd
 from agno.team import Team
+from agno.tools.googlesearch import GoogleSearchTools
 from agno.tools.reasoning import ReasoningTools  # type: ignore
 
 from utils import technical_analysis as ta_utils
@@ -20,6 +21,7 @@ from utils.logging import log_info
 from utils.model_factory import build_default_model
 
 from ..base_agent import BaseAgent
+from ..tools import vn_company_overview, vn_finance_report, vn_company_news
 
 
 class FundamentalsAgent(BaseAgent):
@@ -28,12 +30,12 @@ class FundamentalsAgent(BaseAgent):
     def __init__(self) -> None:  # noqa: D401
         super().__init__(
             model=build_default_model(),
-            tools=[ReasoningTools(add_instructions=True)],
+            tools=[vn_company_overview, vn_finance_report],
             instructions=(
-                "You are a fundamentals analyst. Given a VN equity ticker, "
-                "outline key financial aspects to consider (growth, margins, "
-                "leverage, cash flows) and list data you would seek. If data "
-                "is not provided, infer cautiously and state assumptions."
+                "You are a fundamentals researcher for Vietnamese stocks. "
+                "Retrieve company profile and financial statements using the provided tools, "
+                "then summarise profitability, growth, leverage and cash flow in markdown. "
+                "End with a small table of key ratios and an overall view: Bullish, Bearish or Neutral."
             ),
             name="fundamentals-agent",
             agent_id="fundamentals-agent",
@@ -57,9 +59,8 @@ class SentimentAgent(BaseAgent):
             model=build_default_model(),
             tools=[ReasoningTools(add_instructions=True)],
             instructions=(
-                "You are a sentiment analyst. Summarize likely investor "
-                "sentiment drivers for the ticker from social and news, "
-                "noting uncertainty when data is not provided."
+                "You are a sentiment analyst monitoring Vietnamese sources. "
+                "Identify crowd mood and key drivers for the ticker, noting uncertainty when data is missing."
             ),
             name="sentiment-agent",
             agent_id="sentiment-agent",
@@ -73,17 +74,45 @@ class SentimentAgent(BaseAgent):
         return content if isinstance(content, str) else str(content or "")
 
 
+class SocialMediaAgent(BaseAgent):
+    """Agent gathering chatter from Vietnamese investment forums."""
+
+    def __init__(self) -> None:  # noqa: D401
+        super().__init__(
+            model=build_default_model(),
+            tools=[
+                GoogleSearchTools(fixed_language="vi"),
+                ReasoningTools(add_instructions=True),
+            ],
+            instructions=(
+                "You are a social media analyst tracking Vietnamese investment forums (Facebook, Reddit, Voz). "
+                "Surface notable discussion themes about the ticker and classify the tone as bullish, bearish or neutral. "
+                "Note when information is sparse."
+            ),
+            name="social-media-agent",
+            agent_id="social-media-agent",
+            description="Social media analysis agent",
+            monitoring=False,
+        )
+
+    def analyse(self, symbol: str) -> str:
+        resp = super().run(
+            f"Summarize Vietnamese social media chatter for {symbol}."
+        )
+        content = getattr(resp, "content", None)
+        return content if isinstance(content, str) else str(content or "")
+
+
 class NewsAgent(BaseAgent):
     """Agent focusing on macro/news catalysts impacting the ticker."""
 
     def __init__(self) -> None:  # noqa: D401
         super().__init__(
             model=build_default_model(),
-            tools=[ReasoningTools(add_instructions=True)],
+            tools=[vn_company_news, ReasoningTools(add_instructions=True)],
             instructions=(
-                "You are a news analyst. Identify plausible macro/company "
-                "catalysts, potential scenarios and how they might affect the "
-                "ticker. Note assumptions explicitly."
+                "You are a news analyst for Vietnamese equities. Use the news tool to gather recent headlines "
+                "and combine with macro context to explain catalysts and their likely impact. State assumptions explicitly."
             ),
             name="news-agent",
             agent_id="news-agent",
@@ -186,6 +215,7 @@ class ResearchTeam:
         self.sentiment_agent = SentimentAgent()
         self.news_agent = NewsAgent()
         self.technical_agent = TechnicalResearchAgent()
+        self.social_media_agent = SocialMediaAgent()
 
         # Agno Team for coordinated synthesis
         self.team = Team(
@@ -195,6 +225,8 @@ class ResearchTeam:
                 self.fundamentals_agent,
                 self.sentiment_agent,
                 self.news_agent,
+                self.technical_agent,
+                self.social_media_agent,
             ],
             show_members_responses=False,
             markdown=True,
@@ -232,7 +264,9 @@ class ResearchTeam:
             "### Synthesis\n"
             "- Fundamentals: <2 short bullets>\n"
             "- Sentiment: <2 short bullets>\n"
-            "- News/Catalysts: <2 short bullets>\n\n"
+            "- News/Catalysts: <2 short bullets>\n"
+            "- Technicals: <2 short bullets>\n"
+            "- Social Media: <2 short bullets>\n\n"
             "### Key Risks\n"
             "- bullet\n- bullet\n\n"
             "### Watchlist\n"

--- a/agents/tools.py
+++ b/agents/tools.py
@@ -96,3 +96,33 @@ def vn_finance_report(
     if not isinstance(df, pd.DataFrame):
         df = pd.DataFrame(df)
     return {"columns": list(df.columns), "records": df.to_dict(orient="records")}
+
+
+@tool
+def vn_company_news(
+    symbol: str,
+    *,
+    page_size: int = 15,
+    page: int = 0,
+    source: str | None = None,
+) -> dict[str, Any]:
+    """Fetch recent company news via ``vnstock.Company``.
+
+    Args:
+        symbol: Ticker symbol, e.g., "VCB".
+        page_size: Number of news items to fetch.
+        page: Page index for pagination.
+        source: Data source (VCI|TCBS|MSN). Defaults to settings.VNSTOCK_SOURCE.
+
+    Returns:
+        A dict with keys ``columns`` and ``records`` representing the news
+        table.
+    """
+
+    src = (source or settings.VNSTOCK_SOURCE).upper()
+    df = Company(symbol=symbol, source=src).news(
+        page_size=page_size, page=page
+    )  # type: ignore[arg-type]
+    if not isinstance(df, pd.DataFrame):
+        df = pd.DataFrame(df)
+    return {"columns": list(df.columns), "records": df.to_dict(orient="records")}


### PR DESCRIPTION
## Summary
- Streamline ResearchManager and RiskManager with reusable prompts and agent registries
- Introduce a simple TradingGraph that sequences research, trade decision, and risk review

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ab11ec08325a6c4d74d1c5ef971